### PR TITLE
Modify colliders and jumping logic

### DIFF
--- a/Basic Game/Assets/Animations/jump.anim
+++ b/Basic Game/Assets/Animations/jump.anim
@@ -21,7 +21,7 @@ AnimationClip:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
-        time: 0.083333336
+        time: 0.16666667
         value: 1
         inSlope: Infinity
         outSlope: Infinity
@@ -72,7 +72,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.083333336
+    m_StopTime: 0.16666667
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -92,7 +92,7 @@ AnimationClip:
       serializedVersion: 2
       m_Curve:
       - serializedVersion: 3
-        time: 0.083333336
+        time: 0.16666667
         value: 1
         inSlope: Infinity
         outSlope: Infinity

--- a/Basic Game/Assets/Prefabs/Link.prefab
+++ b/Basic Game/Assets/Prefabs/Link.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7805810481725911835}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.019, y: -0.009, z: -8.278818}
+  m_LocalPosition: {x: -0.074, y: 0.136, z: -8.278818}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -292,7 +292,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -395655314, guid: 2e20c2f71e0bac04990aedd4de57d142, type: 3}
+  m_Sprite: {fileID: -795472712, guid: 2e20c2f71e0bac04990aedd4de57d142, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -342,7 +342,7 @@ PolygonCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7805810482598798376}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
@@ -463,9 +463,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fde4ea0ae88b9b4090645cc0517adeb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  jump: 520
-  clip_jump: {fileID: 0}
-  clip_hurt: {fileID: 0}
+  jumpForce: 530
+  clip_jump: {fileID: 8300000, guid: 366c55d77cc63a54d92acc6e186b48ae, type: 3}
+  clip_hurt: {fileID: 8300000, guid: ccbdc19039fc98542b643efe42ef9a16, type: 3}
 --- !u!82 &6596156853863108880
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Basic Game/Assets/Prefabs/SideEnemy.prefab
+++ b/Basic Game/Assets/Prefabs/SideEnemy.prefab
@@ -128,7 +128,7 @@ PolygonCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}

--- a/Basic Game/Assets/Scenes/SampleScene.unity
+++ b/Basic Game/Assets/Scenes/SampleScene.unity
@@ -2035,7 +2035,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7805810482598798356, guid: fd3518818b1170349a4532ecd15d69ac, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7805810482704035968, guid: fd3518818b1170349a4532ecd15d69ac, type: 3}
       propertyPath: m_Name
@@ -2053,6 +2053,10 @@ PrefabInstance:
       propertyPath: clip_jump
       value: 
       objectReference: {fileID: 8300000, guid: 366c55d77cc63a54d92acc6e186b48ae, type: 3}
+    - target: {fileID: 7805810482704035970, guid: fd3518818b1170349a4532ecd15d69ac, type: 3}
+      propertyPath: jumpForce
+      value: 530
+      objectReference: {fileID: 0}
     - target: {fileID: 7805810482704035971, guid: fd3518818b1170349a4532ecd15d69ac, type: 3}
       propertyPath: m_RootOrder
       value: 1

--- a/Basic Game/Assets/Sprites/Tiles/Palettes/Ground-Tiles/Ground Tiles.prefab
+++ b/Basic Game/Assets/Sprites/Tiles/Palettes/Ground-Tiles/Ground Tiles.prefab
@@ -381,7 +381,7 @@ TilemapRenderer:
   m_Mode: 0
   m_DetectChunkCullingBounds: 0
   m_MaskInteraction: 0
---- !u!114 &3077166742998086918
+--- !u!114 &3200654959179418489
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Basic Game/Assets/Sprites/Tiles/tileset.png.meta
+++ b/Basic Game/Assets/Sprites/Tiles/tileset.png.meta
@@ -43,7 +43,7 @@ TextureImporter:
   lightmap: 0
   compressionQuality: 50
   spriteMode: 2
-  spriteExtrude: 1
+  spriteExtrude: 0
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
@@ -125,7 +125,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -146,7 +146,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -167,7 +167,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -188,10 +188,27 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
-      outline: []
-      physicsShape: []
+      outline:
+      - - {x: 0.028007507, y: 5.1242027}
+        - {x: -4.117386, y: 4.0126915}
+        - {x: -8, y: 2.8736687}
+        - {x: -8, y: -8}
+        - {x: 8, y: -8}
+        - {x: 8, y: 3.0280075}
+        - {x: 5.6856613, y: 4.026024}
+        - {x: 3.6331863, y: 3.1622543}
+      physicsShape:
+      - - {x: 4, y: 3}
+        - {x: 3, y: 3}
+        - {x: 0, y: 5}
+        - {x: -5, y: 4}
+        - {x: -8, y: 3}
+        - {x: -8, y: -8}
+        - {x: 8, y: -8}
+        - {x: 8, y: 3}
+        - {x: 6, y: 4}
       tessellationDetail: 0
       bones: []
       spriteID: 0fc98e9d92167df189e62b9fc1622928
@@ -209,7 +226,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -230,7 +247,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -251,7 +268,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -272,7 +289,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -293,7 +310,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -314,7 +331,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -335,7 +352,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -356,10 +373,72 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
-      outline: []
-      physicsShape: []
+      outline:
+      - - {x: 6.827652, y: 2.8195028}
+        - {x: 4.5637054, y: 3.8592968}
+        - {x: 2.054039, y: 5.9237013}
+        - {x: 1.5774841, y: 7.969516}
+        - {x: 0.034233093, y: 6.5984545}
+        - {x: -2.338768, y: 6.609997}
+        - {x: -6.025879, y: 3.084116}
+        - {x: -7.9574966, y: -0.96898746}
+        - {x: -8, y: -3.9618301}
+        - {x: -6.839485, y: -5.9109073}
+        - {x: -5.653816, y: -7.029597}
+        - {x: -3.1193085, y: -7.005375}
+        - {x: -3.044258, y: -8}
+        - {x: 3.9967194, y: -8}
+        - {x: 4.034012, y: -7.0214524}
+        - {x: 6.0207977, y: -7.0077276}
+        - {x: 8, y: -2.9416614}
+        - {x: 7.957489, y: 0.8588152}
+      physicsShape:
+      - - {x: 7, y: 1}
+        - {x: 7, y: 3}
+        - {x: 6, y: 3}
+        - {x: 6, y: 2}
+        - {x: 5, y: 2}
+        - {x: 5, y: 4}
+        - {x: 4, y: 4}
+        - {x: 4, y: 3}
+        - {x: 3, y: 3}
+        - {x: 3, y: 6}
+        - {x: 2, y: 6}
+        - {x: 2, y: 8}
+        - {x: 1, y: 8}
+        - {x: 1, y: 7}
+        - {x: 0, y: 7}
+        - {x: 0, y: 6}
+        - {x: -1, y: 6}
+        - {x: -1, y: 5}
+        - {x: -2, y: 5}
+        - {x: -2, y: 7}
+        - {x: -3, y: 7}
+        - {x: -3, y: 6}
+        - {x: -4, y: 6}
+        - {x: -4, y: 2}
+        - {x: -5, y: 2}
+        - {x: -5, y: 3}
+        - {x: -7, y: 3}
+        - {x: -7, y: -1}
+        - {x: -8, y: -1}
+        - {x: -8, y: -4}
+        - {x: -7, y: -4}
+        - {x: -7, y: -6}
+        - {x: -6, y: -6}
+        - {x: -6, y: -7}
+        - {x: -3, y: -7}
+        - {x: -3, y: -8}
+        - {x: 4, y: -8}
+        - {x: 4, y: -7}
+        - {x: 6, y: -7}
+        - {x: 6, y: -5}
+        - {x: 7, y: -5}
+        - {x: 7, y: -3}
+        - {x: 8, y: -3}
+        - {x: 8, y: 1}
       tessellationDetail: 0
       bones: []
       spriteID: a6d11d776285fe742b816a3bb55160c2
@@ -377,7 +456,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Basic Game/Assets/Sprites/link.png.meta
+++ b/Basic Game/Assets/Sprites/link.png.meta
@@ -125,7 +125,7 @@ TextureImporter:
         width: 15
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -146,7 +146,7 @@ TextureImporter:
         width: 14
         height: 15
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -166,8 +166,8 @@ TextureImporter:
         y: 492
         width: 17
         height: 17
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.55418485, y: 0.4119496}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []


### PR DESCRIPTION
Link will no longer have a double jump exploit on respawn 
Obstacle colliders will match Sprites
Holding down space allows you to keep jumping
    This also fixes a bug where you could stay on the jump frame forever